### PR TITLE
feat(colors): add IA color tokens

### DIFF
--- a/Sources/Core/Content/Colors/Colors.swift
+++ b/Sources/Core/Content/Colors/Colors.swift
@@ -19,6 +19,7 @@ public protocol Colors: Hashable, Equatable {
     var base: any ColorsBase { get }
     var feedback: any ColorsFeedback { get }
     var states: any ColorsStates { get }
+    var ia: any ColorsIA { get }
 }
 
 // MARK: - Hashable & Equatable
@@ -32,6 +33,7 @@ public extension Colors {
         hasher.combine(self.base)
         hasher.combine(self.feedback)
         hasher.combine(self.states)
+        hasher.combine(self.ia)
     }
 
     func equals(_ other: any Colors) -> Bool {
@@ -40,7 +42,8 @@ public extension Colors {
         self.accent.equals(other.accent) &&
         self.base.equals(other.base) &&
         self.feedback.equals(other.feedback) &&
-        self.states.equals(other.states)
+        self.states.equals(other.states) &&
+        self.ia.equals(other.ia)
     }
 
     static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/Core/Content/Colors/ColorsDefault.swift
+++ b/Sources/Core/Content/Colors/ColorsDefault.swift
@@ -19,6 +19,7 @@ public struct ColorsDefault: Colors {
     public let base: any ColorsBase
     public let feedback: any ColorsFeedback
     public let states: any ColorsStates
+    public let ia: any ColorsIA
 
     // MARK: - Initialization
 
@@ -28,7 +29,8 @@ public struct ColorsDefault: Colors {
         accent: any ColorsAccent,
         base: any ColorsBase,
         feedback: any ColorsFeedback,
-        states: any ColorsStates
+        states: any ColorsStates,
+        ia: any ColorsIA
     ) {
         self.main = main
         self.support = support
@@ -36,5 +38,6 @@ public struct ColorsDefault: Colors {
         self.base = base
         self.feedback = feedback
         self.states = states
+        self.ia = ia
     }
 }

--- a/Sources/Core/Content/Colors/Content/IA/ColorsIA.swift
+++ b/Sources/Core/Content/Colors/Content/IA/ColorsIA.swift
@@ -1,0 +1,38 @@
+//
+//  ColorsIA.swift
+//  SparkTheming
+//
+//  Created by robin.lemaire on 02/06/2026.
+//  Copyright © 2023 Leboncoin. All rights reserved.
+//
+
+// sourcery: AutoMockable
+public protocol ColorsIA: Hashable, Equatable {
+    var ia: any ColorToken { get }
+    var onIA: any ColorToken { get }
+    var iaContainer: any ColorToken { get }
+    var onIAContainer: any ColorToken { get }
+}
+
+// MARK: - Hashable & Equatable
+
+public extension ColorsIA {
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.ia)
+        hasher.combine(self.onIA)
+        hasher.combine(self.iaContainer)
+        hasher.combine(self.onIAContainer)
+    }
+
+    func equals(_ other: any ColorsIA) -> Bool {
+        return self.ia.equals(other.ia) &&
+        self.onIA.equals(other.onIA) &&
+        self.iaContainer.equals(other.iaContainer) &&
+        self.onIAContainer.equals(other.onIAContainer)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.equals(rhs)
+    }
+}

--- a/Sources/Core/Content/Colors/Content/IA/ColorsIADefault.swift
+++ b/Sources/Core/Content/Colors/Content/IA/ColorsIADefault.swift
@@ -1,0 +1,31 @@
+//
+//  ColorsIADefault.swift
+//  SparkTheming
+//
+//  Created by robin.lemaire on 02/06/2026.
+//  Copyright © 2023 Leboncoin. All rights reserved.
+//
+
+public struct ColorsIADefault: ColorsIA {
+
+    // MARK: - Properties
+
+    public let ia: any ColorToken
+    public let onIA: any ColorToken
+    public let iaContainer: any ColorToken
+    public let onIAContainer: any ColorToken
+
+    // MARK: - Init
+
+    public init(
+        ia: any ColorToken,
+        onIA: any ColorToken,
+        iaContainer: any ColorToken,
+        onIAContainer: any ColorToken
+    ) {
+        self.ia = ia
+        self.onIA = onIA
+        self.iaContainer = iaContainer
+        self.onIAContainer = onIAContainer
+    }
+}

--- a/Sources/Core/Theme/Rainbow/Content/RainbowColors.swift
+++ b/Sources/Core/Theme/Rainbow/Content/RainbowColors.swift
@@ -102,6 +102,13 @@ struct RainbowColors: Colors {
         neutralContainerPressed: RainbowColorToken(color: .green)
     )
 
+    let ia: any ColorsIA = ColorsIADefault(
+        ia: RainbowColorToken(color: .yellow),
+        onIA: RainbowColorToken(color: .green),
+        iaContainer: RainbowColorToken(color: .blue),
+        onIAContainer: RainbowColorToken(color: .purple)
+    )
+
     // MARK: - Initialization
 
     init() {}

--- a/Sources/Testing/Content/Colors/ColorsGeneratedMock+ExtensionTests.swift
+++ b/Sources/Testing/Content/Colors/ColorsGeneratedMock+ExtensionTests.swift
@@ -21,6 +21,7 @@ public extension ColorsGeneratedMock {
         mock.base = ColorsBaseGeneratedMock.mocked()
         mock.feedback = ColorsFeedbackGeneratedMock.mocked()
         mock.states = ColorsStatesGeneratedMock.mocked()
+        mock.ia = ColorsIAGeneratedMock.mocked()
 
         return mock
     }

--- a/Sources/Testing/Content/Colors/Content/IA/ColorsIAGeneratedMock+ExtensionTests.swift
+++ b/Sources/Testing/Content/Colors/Content/IA/ColorsIAGeneratedMock+ExtensionTests.swift
@@ -1,0 +1,26 @@
+//
+//  ColorsIAGeneratedMock+ExtensionTests.swift
+//  SparkThemingTesting
+//
+//  Created by robin.lemaire on 02/06/2026.
+//  Copyright © 2023 Leboncoin. All rights reserved.
+//
+
+@testable import SparkTheming
+
+public extension ColorsIAGeneratedMock {
+
+    // MARK: - Methods
+
+    static func mocked() -> ColorsIAGeneratedMock {
+        let mock = ColorsIAGeneratedMock()
+
+        mock.underlyingIa = ColorTokenGeneratedMock.random()
+        mock.underlyingOnIA = ColorTokenGeneratedMock.random()
+
+        mock.underlyingIaContainer = ColorTokenGeneratedMock.random()
+        mock.underlyingOnIAContainer = ColorTokenGeneratedMock.random()
+
+        return mock
+    }
+}

--- a/Sources/Theme/Resources/Colors.xcassets/IA/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/IA/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Theme/Resources/Colors.xcassets/IA/ia-container.colorset/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/IA/ia-container.colorset/Contents.json
@@ -1,0 +1,78 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFA",
+          "green" : "0xE0",
+          "red" : "0xC2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x91",
+          "green" : "0x52",
+          "red" : "0x0C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE6",
+          "green" : "0xE6",
+          "red" : "0xE6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        },
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4C",
+          "green" : "0x4C",
+          "red" : "0x4C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Theme/Resources/Colors.xcassets/IA/ia.colorset/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/IA/ia.colorset/Contents.json
@@ -1,0 +1,78 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x91",
+          "green" : "0x52",
+          "red" : "0x0C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF7",
+          "green" : "0xCE",
+          "red" : "0x9F"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x48",
+          "green" : "0x48",
+          "red" : "0x48"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        },
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBC",
+          "green" : "0xBC",
+          "red" : "0xBC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Theme/Resources/Colors.xcassets/IA/on-ia-container.colorset/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/IA/on-ia-container.colorset/Contents.json
@@ -1,0 +1,78 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x91",
+          "green" : "0x52",
+          "red" : "0x0C"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFE",
+          "green" : "0xF9",
+          "red" : "0xF4"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1A",
+          "green" : "0x1A",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        },
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF9",
+          "green" : "0xF9",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Theme/Resources/Colors.xcassets/IA/on-ia.colorset/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/IA/on-ia.colorset/Contents.json
@@ -1,0 +1,78 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x33",
+          "green" : "0x22",
+          "red" : "0x15"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF9",
+          "green" : "0xF9",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        },
+        {
+          "appearance" : "contrast",
+          "value" : "high"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1A",
+          "green" : "0x1A",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/Theme/Theming/Spark/Content/SparkColors.swift
+++ b/Sources/Theme/Theming/Spark/Content/SparkColors.swift
@@ -20,7 +20,8 @@ struct SparkColors: Colors {
         mainVariant: ColorTokenDefault(named: "main-variant", in: .module),
         onMainVariant: ColorTokenDefault(named: "on-main-variant", in: .module),
         mainContainer: ColorTokenDefault(named: "main-container", in: .module),
-        onMainContainer: ColorTokenDefault(named: "on-main-container", in: .module))
+        onMainContainer: ColorTokenDefault(named: "on-main-container", in: .module)
+    )
 
     let support: any ColorsSupport = ColorsSupportDefault(
         support: ColorTokenDefault(named: "support", in: .module),
@@ -28,7 +29,8 @@ struct SparkColors: Colors {
         supportVariant: ColorTokenDefault(named: "support-variant", in: .module),
         onSupportVariant: ColorTokenDefault(named: "on-support-variant", in: .module),
         supportContainer: ColorTokenDefault(named: "support-container", in: .module),
-        onSupportContainer: ColorTokenDefault(named: "on-support-container", in: .module))
+        onSupportContainer: ColorTokenDefault(named: "on-support-container", in: .module)
+    )
 
     let accent: any ColorsAccent = ColorsAccentDefault(
         accent: ColorTokenDefault(named: "accent", in: .module),
@@ -36,7 +38,8 @@ struct SparkColors: Colors {
         accentVariant: ColorTokenDefault(named: "accent-variant", in: .module),
         onAccentVariant: ColorTokenDefault(named: "on-accent-variant", in: .module),
         accentContainer: ColorTokenDefault(named: "accent-container", in: .module),
-        onAccentContainer: ColorTokenDefault(named: "on-accent-container", in: .module))
+        onAccentContainer: ColorTokenDefault(named: "on-accent-container", in: .module)
+    )
 
     let base: any ColorsBase = ColorsBaseDefault(
         background: ColorTokenDefault(named: "background", in: .module),
@@ -50,7 +53,8 @@ struct SparkColors: Colors {
         outline: ColorTokenDefault(named: "outline", in: .module),
         outlineHigh: ColorTokenDefault(named: "outline-high", in: .module),
         overlay: ColorTokenDefault(named: "overlay", in: .module),
-        onOverlay: ColorTokenDefault(named: "on-overlay", in: .module))
+        onOverlay: ColorTokenDefault(named: "on-overlay", in: .module)
+    )
 
     let feedback: any ColorsFeedback = ColorsFeedbackDefault(
         success: ColorTokenDefault(named: "success", in: .module),
@@ -96,7 +100,15 @@ struct SparkColors: Colors {
         infoPressed: ColorTokenDefault(named: "info-pressed", in: .module),
         infoContainerPressed: ColorTokenDefault(named: "info-container-pressed", in: .module),
         neutralPressed: ColorTokenDefault(named: "neutral-pressed", in: .module),
-        neutralContainerPressed: ColorTokenDefault(named: "neutral-container-pressed", in: .module))
+        neutralContainerPressed: ColorTokenDefault(named: "neutral-container-pressed", in: .module)
+    )
+
+    let ia: any ColorsIA = ColorsIADefault(
+        ia: ColorTokenDefault(named: "ia", in: .module),
+        onIA: ColorTokenDefault(named: "on-ia", in: .module),
+        iaContainer: ColorTokenDefault(named: "ia-container", in: .module),
+        onIAContainer: ColorTokenDefault(named: "on-ia-container", in: .module)
+    )
 
     // MARK: - Initialization
 

--- a/Tests/UnitTests/Core/Content/Colors/ColorsMock.swift
+++ b/Tests/UnitTests/Core/Content/Colors/ColorsMock.swift
@@ -98,6 +98,12 @@ final class ColorsMock {
                 infoContainerPressed: ColorTokenGeneratedMock.yellow(),
                 neutralPressed: ColorTokenGeneratedMock.purple(),
                 neutralContainerPressed: ColorTokenGeneratedMock.red()
+            ),
+            ia: ColorsIADefault(
+                ia: ColorTokenGeneratedMock.red(),
+                onIA: ColorTokenGeneratedMock.blue(),
+                iaContainer: ColorTokenGeneratedMock.green(),
+                onIAContainer: ColorTokenGeneratedMock.orange()
             )
         )
     }
@@ -186,6 +192,12 @@ final class ColorsMock {
                 infoContainerPressed: ColorTokenGeneratedMock.yellow(),
                 neutralPressed: ColorTokenGeneratedMock.purple(),
                 neutralContainerPressed: ColorTokenGeneratedMock.red()
+            ),
+            ia: ColorsIADefault(
+                ia: ColorTokenGeneratedMock.red(),
+                onIA: ColorTokenGeneratedMock.blue(),
+                iaContainer: ColorTokenGeneratedMock.green(),
+                onIAContainer: ColorTokenGeneratedMock.orange()
             )
         )
     }
@@ -274,6 +286,12 @@ final class ColorsMock {
                 infoContainerPressed: ColorTokenGeneratedMock.clear,
                 neutralPressed: ColorTokenGeneratedMock.clear,
                 neutralContainerPressed: ColorTokenGeneratedMock.clear
+            ),
+            ia: ColorsIADefault(
+                ia: ColorTokenGeneratedMock.clear,
+                onIA: ColorTokenGeneratedMock.clear,
+                iaContainer: ColorTokenGeneratedMock.clear,
+                onIAContainer: ColorTokenGeneratedMock.clear
             )
         )
     }


### PR DESCRIPTION
Add new IA (AI) color tokens to the theming system including ia, onIA, iaContainer, and onIAContainer colors. Update Colors protocol and all implementations (Rainbow, Spark) to support the new IA color group.