### PR TITLE
feat(colors): add ia pressed and ia container pressed states

### DIFF
--- a/Sources/Core/Content/Colors/Content/States/ColorsStates.swift
+++ b/Sources/Core/Content/Colors/Content/States/ColorsStates.swift
@@ -44,6 +44,11 @@ public protocol ColorsStates: Hashable, Equatable {
     var infoContainerPressed: any ColorToken { get }
     var neutralPressed: any ColorToken { get }
     var neutralContainerPressed: any ColorToken { get }
+
+    // MARK: - IA
+
+    var iaPressed: any ColorToken { get }
+    var iaContainerPressed: any ColorToken { get }
 }
 
 // MARK: - Hashable & Equatable
@@ -75,6 +80,8 @@ public extension ColorsStates {
         hasher.combine(self.infoContainerPressed)
         hasher.combine(self.neutralPressed)
         hasher.combine(self.neutralContainerPressed)
+        hasher.combine(self.iaPressed)
+        hasher.combine(self.iaContainerPressed)
     }
 
     func equals(_ other: any ColorsStates) -> Bool {
@@ -101,7 +108,9 @@ public extension ColorsStates {
         self.infoPressed.equals(other.infoPressed) &&
         self.infoContainerPressed.equals(other.infoContainerPressed) &&
         self.neutralPressed.equals(other.neutralPressed) &&
-        self.neutralContainerPressed.equals(other.neutralContainerPressed)
+        self.neutralContainerPressed.equals(other.neutralContainerPressed) &&
+        self.iaPressed.equals(other.iaPressed) &&
+        self.iaContainerPressed.equals(other.iaContainerPressed)
     }
 
     static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/Core/Content/Colors/Content/States/ColorsStatesDefault.swift
+++ b/Sources/Core/Content/Colors/Content/States/ColorsStatesDefault.swift
@@ -31,6 +31,8 @@ public struct ColorsStatesDefault: ColorsStates {
     public let infoContainerPressed: any ColorToken
     public let neutralPressed: any ColorToken
     public let neutralContainerPressed: any ColorToken
+    public let iaPressed: any ColorToken
+    public let iaContainerPressed: any ColorToken
 
     // MARK: - Init
 
@@ -55,7 +57,9 @@ public struct ColorsStatesDefault: ColorsStates {
         infoPressed: any ColorToken,
         infoContainerPressed: any ColorToken,
         neutralPressed: any ColorToken,
-        neutralContainerPressed: any ColorToken
+        neutralContainerPressed: any ColorToken,
+        iaPressed: any ColorToken,
+        iaContainerPressed: any ColorToken
     ) {
         self.mainPressed = mainPressed
         self.mainVariantPressed = mainVariantPressed
@@ -78,5 +82,7 @@ public struct ColorsStatesDefault: ColorsStates {
         self.infoContainerPressed = infoContainerPressed
         self.neutralPressed = neutralPressed
         self.neutralContainerPressed = neutralContainerPressed
+        self.iaPressed = iaPressed
+        self.iaContainerPressed = iaContainerPressed
     }
 }

--- a/Sources/Core/Theme/Rainbow/Content/RainbowColors.swift
+++ b/Sources/Core/Theme/Rainbow/Content/RainbowColors.swift
@@ -99,7 +99,9 @@ struct RainbowColors: Colors {
         infoPressed: RainbowColorToken(color: .blue),
         infoContainerPressed: RainbowColorToken(color: .purple),
         neutralPressed: RainbowColorToken(color: .blue),
-        neutralContainerPressed: RainbowColorToken(color: .green)
+        neutralContainerPressed: RainbowColorToken(color: .green),
+        iaPressed: RainbowColorToken(color: .yellow),
+        iaContainerPressed: RainbowColorToken(color: .orange)
     )
 
     let ia: any ColorsIA = ColorsIADefault(

--- a/Sources/Testing/Content/Colors/Content/States/ColorsStatesGeneratedMock+ExtensionTests.swift
+++ b/Sources/Testing/Content/Colors/Content/States/ColorsStatesGeneratedMock+ExtensionTests.swift
@@ -40,6 +40,8 @@ public extension ColorsStatesGeneratedMock {
         mock.underlyingInfoContainerPressed = ColorTokenGeneratedMock.random()
         mock.underlyingNeutralPressed = ColorTokenGeneratedMock.random()
         mock.underlyingNeutralContainerPressed = ColorTokenGeneratedMock.random()
+        mock.underlyingIaPressed = ColorTokenGeneratedMock.random()
+        mock.underlyingIaContainerPressed = ColorTokenGeneratedMock.random()
 
         return mock
     }

--- a/Sources/Theme/Resources/Colors.xcassets/IA/ia-container.colorset/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/IA/ia-container.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFA",
-          "green" : "0xE0",
-          "red" : "0xC2"
+          "blue" : "0xF4",
+          "green" : "0xEA",
+          "red" : "0xF8"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x91",
-          "green" : "0x52",
-          "red" : "0x0C"
+          "blue" : "0x51",
+          "green" : "0x22",
+          "red" : "0x54"
         }
       },
       "idiom" : "universal"

--- a/Sources/Theme/Resources/Colors.xcassets/IA/on-ia-container.colorset/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/IA/on-ia-container.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x91",
-          "green" : "0x52",
-          "red" : "0x0C"
+          "blue" : "0x10",
+          "green" : "0x11",
+          "red" : "0x14"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFE",
-          "green" : "0xF9",
-          "red" : "0xF4"
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/Sources/Theme/Resources/Colors.xcassets/IA/on-ia.colorset/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/IA/on-ia.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x33",
-          "green" : "0x22",
-          "red" : "0x15"
+          "blue" : "0x10",
+          "green" : "0x11",
+          "red" : "0x14"
         }
       },
       "idiom" : "universal"

--- a/Sources/Theme/Resources/Colors.xcassets/States/ia-container-pressed.colorset/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/States/ia-container-pressed.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x9A",
-          "green" : "0x47",
-          "red" : "0xA1"
+          "blue" : "0xE6",
+          "green" : "0xCD",
+          "red" : "0xF0"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xB9",
-          "green" : "0x77",
-          "red" : "0xD2"
+          "blue" : "0x7D",
+          "green" : "0x36",
+          "red" : "0x80"
         }
       },
       "idiom" : "universal"
@@ -41,9 +41,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x48",
-          "green" : "0x48",
-          "red" : "0x48"
+          "blue" : "0xF1",
+          "green" : "0xF1",
+          "red" : "0xF1"
         }
       },
       "idiom" : "universal"
@@ -63,9 +63,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xBC",
-          "green" : "0xBC",
-          "red" : "0xBC"
+          "blue" : "0x30",
+          "green" : "0x30",
+          "red" : "0x30"
         }
       },
       "idiom" : "universal"

--- a/Sources/Theme/Resources/Colors.xcassets/States/ia-pressed.colorset/Contents.json
+++ b/Sources/Theme/Resources/Colors.xcassets/States/ia-pressed.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x9A",
-          "green" : "0x47",
-          "red" : "0xA1"
+          "blue" : "0x7D",
+          "green" : "0x36",
+          "red" : "0x80"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xB9",
-          "green" : "0x77",
-          "red" : "0xD2"
+          "blue" : "0xCE",
+          "green" : "0x98",
+          "red" : "0xE3"
         }
       },
       "idiom" : "universal"
@@ -41,9 +41,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x48",
-          "green" : "0x48",
-          "red" : "0x48"
+          "blue" : "0x5E",
+          "green" : "0x5E",
+          "red" : "0x5E"
         }
       },
       "idiom" : "universal"
@@ -63,9 +63,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xBC",
-          "green" : "0xBC",
-          "red" : "0xBC"
+          "blue" : "0x8D",
+          "green" : "0x8D",
+          "red" : "0x8D"
         }
       },
       "idiom" : "universal"

--- a/Sources/Theme/Theming/Spark/Content/SparkColors.swift
+++ b/Sources/Theme/Theming/Spark/Content/SparkColors.swift
@@ -100,7 +100,9 @@ struct SparkColors: Colors {
         infoPressed: ColorTokenDefault(named: "info-pressed", in: .module),
         infoContainerPressed: ColorTokenDefault(named: "info-container-pressed", in: .module),
         neutralPressed: ColorTokenDefault(named: "neutral-pressed", in: .module),
-        neutralContainerPressed: ColorTokenDefault(named: "neutral-container-pressed", in: .module)
+        neutralContainerPressed: ColorTokenDefault(named: "neutral-container-pressed", in: .module),
+        iaPressed: ColorTokenDefault(named: "ia-pressed", in: .module),
+        iaContainerPressed: ColorTokenDefault(named: "ia-container-pressed", in: .module)
     )
 
     let ia: any ColorsIA = ColorsIADefault(

--- a/Tests/UnitTests/Core/Content/Colors/ColorsMock.swift
+++ b/Tests/UnitTests/Core/Content/Colors/ColorsMock.swift
@@ -97,7 +97,9 @@ final class ColorsMock {
                 infoPressed: ColorTokenGeneratedMock.orange(),
                 infoContainerPressed: ColorTokenGeneratedMock.yellow(),
                 neutralPressed: ColorTokenGeneratedMock.purple(),
-                neutralContainerPressed: ColorTokenGeneratedMock.red()
+                neutralContainerPressed: ColorTokenGeneratedMock.red(),
+                iaPressed: ColorTokenGeneratedMock.blue(),
+                iaContainerPressed: ColorTokenGeneratedMock.green()
             ),
             ia: ColorsIADefault(
                 ia: ColorTokenGeneratedMock.red(),
@@ -191,7 +193,9 @@ final class ColorsMock {
                 infoPressed: ColorTokenGeneratedMock.orange(),
                 infoContainerPressed: ColorTokenGeneratedMock.yellow(),
                 neutralPressed: ColorTokenGeneratedMock.purple(),
-                neutralContainerPressed: ColorTokenGeneratedMock.red()
+                neutralContainerPressed: ColorTokenGeneratedMock.red(),
+                iaPressed: ColorTokenGeneratedMock.blue(),
+                iaContainerPressed: ColorTokenGeneratedMock.green()
             ),
             ia: ColorsIADefault(
                 ia: ColorTokenGeneratedMock.red(),
@@ -285,7 +289,9 @@ final class ColorsMock {
                 infoPressed: ColorTokenGeneratedMock.clear,
                 infoContainerPressed: ColorTokenGeneratedMock.clear,
                 neutralPressed: ColorTokenGeneratedMock.clear,
-                neutralContainerPressed: ColorTokenGeneratedMock.clear
+                neutralContainerPressed: ColorTokenGeneratedMock.clear,
+                iaPressed: ColorTokenGeneratedMock.clear,
+                iaContainerPressed: ColorTokenGeneratedMock.clear
             ),
             ia: ColorsIADefault(
                 ia: ColorTokenGeneratedMock.clear,


### PR DESCRIPTION
Add new pressed state color tokens for IA colors to ColorsStates protocol and implementations.

Changes:
- Add iaPressed and iaContainerPressed properties to ColorsStates protocol
- Update ColorsStatesDefault with new properties and initializer parameters
- Add ia-pressed and ia-container-pressed color assets in SparkTheme
- Update SparkColors implementation with named color tokens
- Update RainbowColors implementation with rainbow color tokens
- Update ColorsStatesGeneratedMock extension with new mock properties
- Update ColorsMock test implementations for all mock methods
- Update hash and equals methods to include new properties