### PR TITLE
feat(typography): add custom font token method

### DIFF
--- a/Sources/Core/Content/Typography/Typography.swift
+++ b/Sources/Core/Content/Typography/Typography.swift
@@ -33,6 +33,12 @@ public protocol Typography: Hashable, Equatable {
     var smallHighlight: any TypographyFontToken { get }
 
     var callout: any TypographyFontToken { get }
+
+    func custom(
+        size: CGFloat,
+        style: TypographyFontStyle,
+        textStyle: TextStyle
+    ) -> any TypographyFontToken
 }
 
 // MARK: - Hashable & Equatable

--- a/Sources/Core/Content/Typography/TypographyDefault.swift
+++ b/Sources/Core/Content/Typography/TypographyDefault.swift
@@ -71,4 +71,14 @@ public struct TypographyDefault: Typography {
         self.smallHighlight = smallHighlight
         self.callout = callout
     }
+
+    // MARK: - Methods
+
+    public func custom(
+        size: CGFloat,
+        style: TypographyFontStyle,
+        textStyle: TextStyle
+    ) -> any TypographyFontToken {
+        TypographyFontTokenClear()
+    }
 }

--- a/Sources/Core/Theme/Rainbow/Content/RainbowTypography.swift
+++ b/Sources/Core/Theme/Rainbow/Content/RainbowTypography.swift
@@ -39,6 +39,16 @@ struct RainbowTypography: Typography {
     // MARK: - Initialization
 
     init() {}
+
+    // MARK: - Methods
+
+    func custom(
+        size: CGFloat,
+        style: TypographyFontStyle,
+        textStyle: TextStyle
+    ) -> any TypographyFontToken {
+        RainbowTypographyToken()
+    }
 }
 
 // MARK: - Private Token

--- a/Sources/Testing/Content/Typography/TypographyGeneratedMock+ExtensionTests.swift
+++ b/Sources/Testing/Content/Typography/TypographyGeneratedMock+ExtensionTests.swift
@@ -40,6 +40,8 @@ public extension TypographyGeneratedMock {
 
         typography.callout = TypographyFontTokenGeneratedMock.mocked(.callout)
 
+        typography.customWithSizeAndStyleAndTextStyleReturnValue = TypographyFontTokenGeneratedMock.mocked(.footnote)
+
         return typography
     }
 }

--- a/Sources/Theme/Theming/Spark/Content/SparkTypography.swift
+++ b/Sources/Theme/Theming/Spark/Content/SparkTypography.swift
@@ -100,6 +100,20 @@ struct SparkTypography: Typography {
     // MARK: - Initialization
 
     init() {}
+
+    // MARK: - Methods
+
+    func custom(
+        size: CGFloat,
+        style: TypographyFontStyle,
+        textStyle: TextStyle
+    ) -> any TypographyFontToken {
+        return TypographyFontTokenDefault(
+            size: size,
+            style: style,
+            textStyle: textStyle
+        )
+    }
 }
 
 // MARK: - TypographyFont Extension


### PR DESCRIPTION
Add custom() method to Typography protocol and all implementations to allow creating custom typography font tokens with specified size, style, and text style parameters.

Changes:
- Add custom() method to Typography protocol
- Implement custom() in TypographyDefault (returns TypographyFontTokenClear)
- Implement custom() in RainbowTypography (returns RainbowTypographyToken)
- Implement custom() in SparkTypography (returns TypographyFontTokenDefault with custom parameters)
- Update TypographyGeneratedMock with custom method return value